### PR TITLE
adjusted env var in setup.py to work with hammer deploys

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+[OPTORO INTERNAL] AIRFLOW 1.10.2, 2018-12-03
+Added os.environ["SLUGIFY_USES_TEXT_UNIDECODE"] = "yes" to setup.py to get around not being able to specify it while building with mc-hammer.
+
 AIRFLOW 1.10.1, 2018-11-13
 
 New features:

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.1'
+version = '1.10.2'

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,13 @@ PY3 = sys.version_info[0] == 3
 
 # See LEGAL-362
 def verify_gpl_dependency():
-    # The Read the Docs build environment [1] does a pip install of Airflow which cannot
-    # be overridden with custom environment variables, so we detect the READTHEDOCS env
-    # var they provide to set the env var that avoids the GPL dependency on install when
-    # building the docs site.
-    # [1]: http://docs.readthedocs.io/en/latest/builds.html#build-environment
-    if os.getenv("READTHEDOCS") == "True":
-        os.environ["SLUGIFY_USES_TEXT_UNIDECODE"] = "yes"
+    """
+    Deploying Airflow with mc-hammer doesn't allow the setting
+    of arbitrary env vars before Airflow is installed. By making
+    SLUGIFY_USES_TEXT_UNIDECODE the default, we're hoping to get
+    around this.
+    """
+    os.environ["SLUGIFY_USES_TEXT_UNIDECODE"] = "yes"
 
     if (not os.getenv("AIRFLOW_GPL_UNIDECODE")
             and not os.getenv("SLUGIFY_USES_TEXT_UNIDECODE") == "yes"):


### PR DESCRIPTION
I added `os.environ["SLUGIFY_USES_TEXT_UNIDECODE"] = "yes"` to `setup.py` so we can use airflow with hammer 5+ and with python versions >= 3.6.

I bumped the version so it will be easy for us to include in our internal stuff, but also LMK if there's a better way to do this. It's on optoro's pypi as `apache-airflow==1.10.2`.